### PR TITLE
stricter loading of configuration file

### DIFF
--- a/loader.php
+++ b/loader.php
@@ -59,11 +59,15 @@ if (!defined('CIDRAM')) {
     }
 
     /** Attempts to parse the CIDRAM configuration file. */
-    $CIDRAM['Config'] =
-        (file_exists($CIDRAM['Vault'] . 'config.ini')) ?
-        parse_ini_file($CIDRAM['Vault'] . 'config.ini', true) :
-        array();
-
+    if(!is_readable($CIDRAM['Vault'] . 'config.ini')){
+        header('Content-Type: text/plain');
+        die('[CIDRAM] cannot read the configuration file! Please reconfigure CIDRAM.');
+    }
+    $CIDRAM['Config'] = parse_ini_file($CIDRAM['Vault'] . 'config.ini', true);
+    if(false===$CIDRAM['Config']){
+        header('Content-Type: text/plain');
+        die('[CIDRAM] configuration file is corrupt! Please reconfigure CIDRAM.');
+    }
     /** Fallback for any potential parse failure. */
     if (!is_array($CIDRAM['Config'])) {
         $CIDRAM['Config'] = array();


### PR DESCRIPTION
now if the configuration file isn't readable, it will error out.
if the configuration file is corrupt (per parse_ini_file's definition), it will also error out.

Personally, i  would prefer to throw an exception instead, which would put a notice in the error log, but since the rest of the code use die() style errors, i sticked to it... related to https://github.com/Maikuolan/CIDRAM/issues/10
